### PR TITLE
rerender matrix on size property change

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -52,7 +52,7 @@ export default class QRCode extends PureComponent {
   }
   componentWillUpdate (nextProps) {
     // if value has changed, re-setMatrix
-    if (nextProps.value !== this.props.value) {
+    if (nextProps.value !== this.props.value || nextProps.size !== this.props.size) {
       this.setMatrix(nextProps)
     }
   }


### PR DESCRIPTION
QR code wasn't updated on size prop change. Layout changes are common on mobile when switching from portrait to landscape mode for example.