### PR TITLE
Fix getRef type by adding the c argument per examples

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -25,7 +25,7 @@ export interface QRCodeProps {
   /* the border-radius of logo image */
   logoBorderRadius?: number
   /* get svg ref for further usage */
-  getRef?: () => any
+  getRef?: (c: any) => any
   /* error correction level */
   ecl?: 'L' | 'M' | 'Q' | 'H'
 }


### PR DESCRIPTION
Typescript is complaining as getRef is supposed to get an argument `c: any` but the `index.d.ts` defines it without argument.

Thanks for the great work library :)