### PR TITLE
Add quietZone prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ logoSize | 20% of size | Size of the imprinted logo. Bigger logo = less error co
 logoBackgroundColor | backgroundColor        | The logo gets a filled quadratic background with this color. Use 'transparent' if your logo already has its own backdrop.
 logoMargin | 2 | logo's distance to its wrapper
 logoBorderRadius | 0 | the border-radius of logo image (Android is not supported)
+quietZone | 0 | quiet zone around the qr in pixels (useful when saving image to gallery)
 getRef          | null       | Get SVG ref for further usage
 ecl             | 'M'        | Error correction level
 onError(error)  | undefined  | Callback fired when exception happened during the code generating process

--- a/index.d.ts
+++ b/index.d.ts
@@ -24,6 +24,8 @@ export interface QRCodeProps {
   logoMargin?: number
   /* the border-radius of logo image */
   logoBorderRadius?: number
+  /* quiet zone in pixels */
+  quietZone?: number
   /* get svg ref for further usage */
   getRef?: (c: any) => any
   /* error correction level */

--- a/index.js
+++ b/index.js
@@ -1,1 +1,1 @@
-export { default } from './src/index.js';
+export { default } from './src/index.js'

--- a/src/index.js
+++ b/src/index.js
@@ -127,14 +127,16 @@ export default class QRCode extends PureComponent {
       color,
       backgroundColor,
       logo,
-      quietZone,
       logoBackgroundColor
     } = this.props
 
     const qrScale = QR_SIZE / size
+
+    // scale sizes that relate to qr to match with the size of the whole image
     const logoSize = this.props.logoSize * qrScale
     const logoMargin = this.props.logoMargin * qrScale
     const logoBorderRadius = this.props.logoBorderRadius * qrScale
+    const quietZone = this.props.quietZone * qrScale
 
     const logoPosition = QR_SIZE / 2 - logoSize / 2 - logoMargin
     const logoWrapperSize = logoSize + logoMargin * 2
@@ -149,10 +151,10 @@ export default class QRCode extends PureComponent {
         <Svg
           id='qr-container'
           viewBox={[
-            -quietZone / 2,
-            -quietZone / 2,
-            QR_SIZE + quietZone,
-            QR_SIZE + quietZone
+            -quietZone,
+            -quietZone,
+            QR_SIZE + quietZone * 2,
+            QR_SIZE + quietZone * 2
           ].join(' ')}
           width={size}
           height={size}

--- a/src/index.js
+++ b/src/index.js
@@ -1,59 +1,59 @@
-import React, { PureComponent } from 'react';
-import { Image as RNImage } from 'react-native';
-import PropTypes from 'prop-types';
-import Svg, { Defs, G, Rect, Path, Image, ClipPath } from 'react-native-svg';
-import genMatrix from './genMatrix';
+import React, { PureComponent } from 'react'
+import { Image as RNImage } from 'react-native'
+import PropTypes from 'prop-types'
+import Svg, { Defs, G, Rect, Path, Image, ClipPath } from 'react-native-svg'
+import genMatrix from './genMatrix'
 
-const QR_SIZE = 100;
-const DEFAULT_SIZE = 100;
-const DEFAULT_BG_COLOR = 'white';
+const QR_SIZE = 100
+const DEFAULT_SIZE = 100
+const DEFAULT_BG_COLOR = 'white'
 
 /* calculate the size of the cell and draw the path */
-function calculateMatrix(props) {
-  const { value, ecl, onError } = props;
+function calculateMatrix (props) {
+  const { value, ecl, onError } = props
   try {
-    const matrix = genMatrix(value, ecl);
-    const cellSize = QR_SIZE / matrix.length;
+    const matrix = genMatrix(value, ecl)
+    const cellSize = QR_SIZE / matrix.length
     return {
       value,
       size: QR_SIZE,
       cellSize,
-      path: transformMatrixIntoPath(cellSize, matrix),
-    };
+      path: transformMatrixIntoPath(cellSize, matrix)
+    }
   } catch (error) {
     if (onError && typeof onError === 'function') {
-      onError(error);
+      onError(error)
     } else {
       // Pass the error when no handler presented
-      throw error;
+      throw error
     }
   }
-  return {};
+  return {}
 }
 
 /* project the matrix into path draw */
-function transformMatrixIntoPath(cellSize, matrix) {
-  let d = '';
+function transformMatrixIntoPath (cellSize, matrix) {
+  let d = ''
   matrix.forEach((row, i) => {
-    let needDraw = false;
+    let needDraw = false
     row.forEach((column, j) => {
       if (column) {
         if (!needDraw) {
-          d += `M${cellSize * j} ${cellSize / 2 + cellSize * i} `;
-          needDraw = true;
+          d += `M${cellSize * j} ${cellSize / 2 + cellSize * i} `
+          needDraw = true
         }
         if (needDraw && j === matrix.length - 1) {
-          d += `L${cellSize * (j + 1)} ${cellSize / 2 + cellSize * i} `;
+          d += `L${cellSize * (j + 1)} ${cellSize / 2 + cellSize * i} `
         }
       } else {
         if (needDraw) {
-          d += `L${cellSize * j} ${cellSize / 2 + cellSize * i} `;
-          needDraw = false;
+          d += `L${cellSize * j} ${cellSize / 2 + cellSize * i} `
+          needDraw = false
         }
       }
-    });
-  });
-  return d;
+    })
+  })
+  return d
 }
 
 /**
@@ -107,20 +107,20 @@ export default class QRCode extends PureComponent {
     onError: undefined
   };
 
-  constructor(props) {
-    super(props);
-    this.state = calculateMatrix(props);
+  constructor (props) {
+    super(props)
+    this.state = calculateMatrix(props)
   }
 
-  static getDerivedStateFromProps(props, state) {
+  static getDerivedStateFromProps (props, state) {
     // if value has changed, re-calculateMatrix
     if (props.value !== state.value || props.size !== state.size) {
-      return calculateMatrix(props);
+      return calculateMatrix(props)
     }
-    return null;
+    return null
   }
 
-  render() {
+  render () {
     const {
       getRef,
       size,
@@ -128,37 +128,37 @@ export default class QRCode extends PureComponent {
       backgroundColor,
       logo,
       quietZone,
-      logoBackgroundColor,
-    } = this.props;
+      logoBackgroundColor
+    } = this.props
 
-    const qr_scale = QR_SIZE / size;
-    const logoSize = this.props.logoSize * qr_scale;
-    const logoMargin = this.props.logoMargin * qr_scale;
-    const logoBorderRadius = this.props.logoBorderRadius * qr_scale;
+    const qrScale = QR_SIZE / size
+    const logoSize = this.props.logoSize * qrScale
+    const logoMargin = this.props.logoMargin * qrScale
+    const logoBorderRadius = this.props.logoBorderRadius * qrScale
 
-    const logoPosition = QR_SIZE / 2 - logoSize / 2 - logoMargin;
-    const logoWrapperSize = logoSize + logoMargin * 2;
+    const logoPosition = QR_SIZE / 2 - logoSize / 2 - logoMargin
+    const logoWrapperSize = logoSize + logoMargin * 2
     const logoWrapperBorderRadius =
-      logoBorderRadius + (logoBorderRadius && logoMargin);
+      logoBorderRadius + (logoBorderRadius && logoMargin)
 
-    const { cellSize, path } = this.state;
+    const { cellSize, path } = this.state
 
     return (
-      <Svg id="rn-qr-svg-container" ref={getRef} width={size} height={size}>
+      <Svg id='rn-qr-svg-container' ref={getRef} width={size} height={size}>
         <Rect width={size} height={size} fill={backgroundColor} />
         <Svg
-          id="qr-container"
+          id='qr-container'
           viewBox={[
             -quietZone / 2,
             -quietZone / 2,
             QR_SIZE + quietZone,
-            QR_SIZE + quietZone,
+            QR_SIZE + quietZone
           ].join(' ')}
           width={size}
           height={size}
         >
           <Defs>
-            <ClipPath id="clip-wrapper">
+            <ClipPath id='clip-wrapper'>
               <Rect
                 width={logoWrapperSize}
                 height={logoWrapperSize}
@@ -166,7 +166,7 @@ export default class QRCode extends PureComponent {
                 ry={logoWrapperBorderRadius}
               />
             </ClipPath>
-            <ClipPath id="clip-logo">
+            <ClipPath id='clip-logo'>
               <Rect
                 width={logoSize}
                 height={logoSize}
@@ -184,21 +184,21 @@ export default class QRCode extends PureComponent {
                 width={logoWrapperSize}
                 height={logoWrapperSize}
                 fill={logoBackgroundColor}
-                clipPath="url(#clip-wrapper)"
+                clipPath='url(#clip-wrapper)'
               />
               <G x={logoMargin} y={logoMargin}>
                 <Image
                   width={logoSize}
                   height={logoSize}
-                  preserveAspectRatio="xMidYMid slice"
+                  preserveAspectRatio='xMidYMid slice'
                   href={logo}
-                  clipPath="url(#clip-logo)"
+                  clipPath='url(#clip-logo)'
                 />
               </G>
             </G>
           )}
         </Svg>
       </Svg>
-    );
+    )
   }
 }


### PR DESCRIPTION
This adds support for a `quietZone` prop.

The diff may be a bit difficult to read because I ran `npm standard --fix` to make the pre-commit hook pass, however it made changes to every line, so I recomend you just view [this commit](https://github.com/awesomejerry/react-native-qrcode-svg/commit/5c87c67876abd03406c0749f4ea758adf32be849).

The main changes are:
- Wrap everything in a parent `<Svg>`
- Fix the size of the qr to 100
- Scale the QR using the `viewBox` attribute

This is the best guide to `viewBox` I know of: https://www.sarasoueidan.com/blog/svg-coordinate-systems/#viewbox-syntax


In short:
```jsx
<Svg viewBox={[
  -quietZone,  // move origin-x coordinate "outside" the default viewbox
  -quietZone,  // move origin-y coordinate "outside" the default viewbox
  QR_SIZE + quietZone * 2,  // increase width
  QR_SIZE + quietZone * 2   // increase height
].join(' ')}
/>
```
This leaves half the quiet zone around the whole QR code.