### PR TITLE
background color quietZone

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -128,7 +128,10 @@ const QRCode = ({
         </LinearGradient>
       </Defs>
       <G>
-        <Rect width={size} height={size} fill={backgroundColor} />
+        <Rect 
+        x={-quietZone}
+        y={-quietZone}
+        width={size+(quietZone*2)} height={size+(quietZone*2)} fill={backgroundColor} stroke="rgb(255, 255, 255)"/>
       </G>
       <G>
         <Path


### PR DESCRIPTION
The quietZone attribute was creating a transparent background image when being saved to the gallery, which was resolved.