### PR TITLE
Add the square property and fix the math to work for any given size

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -139,6 +139,7 @@ const QRCode = ({
       <G>
         <Path
           d={path}
+          strokeLinecap={'square'}
           stroke={enableLinearGradient ? 'url(#grad)' : color}
           strokeWidth={cellSize}
         />

--- a/src/transformMatrixIntoPath.js
+++ b/src/transformMatrixIntoPath.js
@@ -1,20 +1,21 @@
 export default (matrix, size) => {
   const cellSize = size / matrix.length
+  const adjustSize = size * 0.024
   let path = ''
   matrix.forEach((row, i) => {
     let needDraw = false
     row.forEach((column, j) => {
       if (column) {
         if (!needDraw) {
-          path += `M${cellSize * j} ${cellSize / 2 + cellSize * i} `
+          path += `M${cellSize * j + adjustSize} ${cellSize / 2 + cellSize * i} `
           needDraw = true
         }
         if (needDraw && j === matrix.length - 1) {
-          path += `L${cellSize * (j + 1)} ${cellSize / 2 + cellSize * i} `
+          path += `L${cellSize * (j + adjustSize)} ${cellSize / 2 + cellSize * i} `
         }
       } else {
         if (needDraw) {
-          path += `L${cellSize * j} ${cellSize / 2 + cellSize * i} `
+          path += `L${cellSize * j - adjustSize} ${cellSize / 2 + cellSize * i} `
           needDraw = false
         }
       }


### PR DESCRIPTION
This PR fixes the issue described [here](https://github.com/awesomejerry/react-native-qrcode-svg/issues/108).