### PR TITLE
feat: add responsive svg support

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { Image, ImageSourcePropType } from "react-native";
+import { Image, ImageSourcePropType, StyleProp, ViewStyle } from "react-native";
 
 declare class QRCode extends React.PureComponent<QRCodeProps, any> {}
 
@@ -37,6 +37,10 @@ export interface QRCodeProps {
   ecl?: "L" | "M" | "Q" | "H";
   /* error handler called when matrix fails to generate */
   onError?: Function;
+  /* style prop; note: overwrites width/height attrs */
+  style?: StyleProp<ViewStyle>;
+  /* positioning and scaling around viewbox */
+  preserveAspectRatio?: string;
 }
 
 export default QRCode;

--- a/src/index.js
+++ b/src/index.js
@@ -82,7 +82,9 @@ const QRCode = ({
   linearGradient = ['rgb(255,0,0)', 'rgb(0,255,255)'],
   ecl = 'M',
   getRef,
-  onError
+  onError,
+  preserveAspectRatio,
+  style
 }) => {
   const result = useMemo(() => {
     try {
@@ -114,6 +116,8 @@ const QRCode = ({
       ].join(' ')}
       width={size}
       height={size}
+      style={style}
+      preserveAspectRatio={preserveAspectRatio}
     >
       <Defs>
         <LinearGradient

--- a/src/index.js
+++ b/src/index.js
@@ -114,8 +114,6 @@ const QRCode = ({
         size + quietZone * 2,
         size + quietZone * 2
       ].join(' ')}
-      width={size}
-      height={size}
       style={style}
       preserveAspectRatio={preserveAspectRatio}
     >


### PR DESCRIPTION
**Edit:** Doh! I Initially thought removing the width/height props wouldn't be required (On web the styles took priority, but not so in RN!)
 
Probably safe to say that puts this PR in "breaking change" territory. I think it'd still be a cool feature to support -- but not sure there's a way to get it done without a flag, or some heuristic inference. 
 
 ---


## Overview
I was looking for a cross-platform solution that would work with web at various device sizes. Worked easily with a couple mods. Thought I'd propose in case it might be useful.

Thanks!

### Changes:
- add `style` prop
- add `preserveAspectRatio` prop
- [edit] **remove width/height props** ❗️

**note**: style + preserveAspectRatio are both compliant with underlying [react-native-svg types](https://github.com/react-native-svg/react-native-svg/blob/fa9a25d36b6f863d3148bdd5dd1ac76e91339402/src/elements/Svg.tsx#L39-L51)

### Example: 
```tsx
<View style={styles.responsiveContainer}>
  <QRCode
    value={value}
    color={COLORS.PRIMARY}
    backgroundColor={COLORS.SECONDARY}
    style={{ width: "100%", height: "100%" }}
  />
</View>
```

**note**: I actually ended up not needing the `preserveAspectRatio` for my implementation -- added it initially after seeing it [mentioned here](https://css-tricks.com/scale-svg/) as being useful for complex SVG scaling -- but left it in as a relevant pass thru prop, since it's an intrinsic to SVGs.