### PR TITLE
chore(typing): update qrcode component typing

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { Image, ImageSourcePropType } from "react-native";
 
-declare class QRCode extends React.PureComponent<QRCodeProps, any> {}
+declare const QRCode: React.FC<QRCodeProps>;
 
 export interface QRCodeProps {
   /* what the qr code stands for */


### PR DESCRIPTION
Just a quick update on typing from `PureComponent` to `React.FC` since the implementation no longer uses a memoized class component.